### PR TITLE
Updated Comparison of SupportedMediaTypes to use the MediaType descripti...

### DIFF
--- a/src/WebAPI.OutputCache/CacheOutputAttribute.cs
+++ b/src/WebAPI.OutputCache/CacheOutputAttribute.cs
@@ -101,7 +101,7 @@ namespace WebAPI.OutputCache
                 {
                     responseMediaType = actionContext.Request.Headers.Accept.FirstOrDefault();
                     if (responseMediaType == null ||
-                        !config.Formatters.Any(x => x.SupportedMediaTypes.Contains(responseMediaType)))
+                        !config.Formatters.Any(x => x.SupportedMediaTypes.Any(value => value.MediaType == responseMediaType.MediaType)))
                     {
                         DefaultMediaType.CharSet = Encoding.UTF8.HeaderName;
                         return DefaultMediaType;


### PR DESCRIPTION
Hello,

I have made this change when comparing media type header values in order to support custom media types that contain parameters. For example consider:

application/vnd.mine+json
and
application/vnd.mine+json; version 2

Those are effectively the same media types but the second contain a 'version' parameter. The existing comparison will not match it with the supported ones but the updated version will.
