### PR TITLE
Support for "cache-control:no-cache" in request

### DIFF
--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -60,7 +60,7 @@ namespace WebApi.OutputCache.V2
             get // required for property visibility
             {
                 if (!_sharedTimeSpan.HasValue)
-                    throw new Exception("should not be called without value set"); 
+                    throw new Exception("should not be called without value set");
                 return _sharedTimeSpan.Value;
             }
             set { _sharedTimeSpan = value; }
@@ -80,7 +80,7 @@ namespace WebApi.OutputCache.V2
         /// Class used to generate caching keys
         /// </summary>
         public Type CacheKeyGenerator { get; set; }
-        
+
         // cache repository
         private IApiOutputCache _webApiCache;
 
@@ -106,7 +106,7 @@ namespace WebApi.OutputCache.V2
                 return false;
             }
 
-            return actionContext.Request.Method == HttpMethod.Get;
+          return actionContext.Request.Method == HttpMethod.Get;
         }
 
         protected virtual void EnsureCacheTimeQuery()
@@ -156,12 +156,18 @@ namespace WebApi.OutputCache.V2
             return responseMediaType;
         }
 
+        private bool IsNoCacheHeaderInRequest(HttpActionContext actionContext)
+        {
+            var cacheControl = actionContext.Request.Headers.CacheControl;
+            return cacheControl != null && cacheControl.NoCache;
+        }
+
         public override void OnActionExecuting(HttpActionContext actionContext)
         {
             if (actionContext == null) throw new ArgumentNullException("actionContext");
 
             if (!IsCachingAllowed(actionContext, AnonymousOnly)) return;
-
+            
             var config = actionContext.Request.GetConfiguration();
 
             EnsureCacheTimeQuery();
@@ -174,6 +180,8 @@ namespace WebApi.OutputCache.V2
             var cachekey = cacheKeyGenerator.MakeCacheKey(actionContext, responseMediaType, ExcludeQueryStringFromCacheKey);
 
             if (!_webApiCache.Contains(cachekey)) return;
+
+            if (IsNoCacheHeaderInRequest(actionContext)) return;
 
             if (actionContext.Request.Headers.IfNoneMatch != null)
             {
@@ -223,6 +231,11 @@ namespace WebApi.OutputCache.V2
                 var responseMediaType = actionExecutedContext.Request.Properties[CurrentRequestMediaType] as MediaTypeHeaderValue ?? GetExpectedMediaType(httpConfig, actionExecutedContext.ActionContext);
                 var cachekey = cacheKeyGenerator.MakeCacheKey(actionExecutedContext.ActionContext, responseMediaType, ExcludeQueryStringFromCacheKey);
 
+                if (IsNoCacheHeaderInRequest(actionExecutedContext.ActionContext))
+                {
+                    _webApiCache.Remove(cachekey);
+                }
+
                 if (!string.IsNullOrWhiteSpace(cachekey) && !(_webApiCache.Contains(cachekey)))
                 {
                     SetEtag(actionExecutedContext.Response, CreateEtag(actionExecutedContext, cachekey, cacheTime));
@@ -242,12 +255,12 @@ namespace WebApi.OutputCache.V2
                         _webApiCache.Add(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
                         _webApiCache.Add(cachekey, content, cacheTime.AbsoluteExpiration, baseKey);
 
-                       
+
                         _webApiCache.Add(cachekey + Constants.ContentTypeKey,
                                         contentType,
                                         cacheTime.AbsoluteExpiration, baseKey);
 
-                       
+
                         _webApiCache.Add(cachekey + Constants.EtagKey,
                                         etag,
                                         cacheTime.AbsoluteExpiration, baseKey);
@@ -263,12 +276,12 @@ namespace WebApi.OutputCache.V2
             if (cacheTime.ClientTimeSpan > TimeSpan.Zero || MustRevalidate || Private)
             {
                 var cachecontrol = new CacheControlHeaderValue
-                                       {
-                                           MaxAge = cacheTime.ClientTimeSpan,
-                                           SharedMaxAge = cacheTime.SharedTimeSpan,
-                                           MustRevalidate = MustRevalidate,
-                                           Private = Private
-                                       };
+                {
+                    MaxAge = cacheTime.ClientTimeSpan,
+                    SharedMaxAge = cacheTime.SharedTimeSpan,
+                    MustRevalidate = MustRevalidate,
+                    Private = Private
+                };
 
                 response.Headers.CacheControl = cachecontrol;
             }
@@ -293,4 +306,4 @@ namespace WebApi.OutputCache.V2
             }
         }
     }
-} 
+}

--- a/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
@@ -84,21 +84,21 @@ namespace WebApi.OutputCache.V2.Tests
         }
 
 
-	    [Test]
-	    public void nocache_headers_correct()
-	    {
-			var client = new HttpClient(_server);
-			var result = client.GetAsync(_url + "Get_nocache").Result;
+        [Test]
+        public void nocache_headers_correct()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_nocache").Result;
 
-			Assert.IsTrue(result.Headers.CacheControl.NoCache,
-				"NoCache in result headers was expected to be true when CacheOutput.NoCache=true.");
-		    Assert.IsTrue(result.Headers.Contains("Pragma"),
-				"result headers does not contain expected Pragma.");
-			Assert.IsTrue(result.Headers.GetValues("Pragma").Contains("no-cache"),
-				"expected no-cache Pragma was not found");
-	    }
+            Assert.IsTrue(result.Headers.CacheControl.NoCache,
+                "NoCache in result headers was expected to be true when CacheOutput.NoCache=true.");
+            Assert.IsTrue(result.Headers.Contains("Pragma"),
+                "result headers does not contain expected Pragma.");
+            Assert.IsTrue(result.Headers.GetValues("Pragma").Contains("no-cache"),
+                "expected no-cache Pragma was not found");
+        }
 
-	    [Test]
+        [Test]
         public void maxage_mustrevalidate_true_headers_correct()
         {
             var client = new HttpClient(_server);
@@ -122,9 +122,9 @@ namespace WebApi.OutputCache.V2.Tests
         public void maxage_mustrevalidate_headers_correct_with_cacheuntil()
         {
             var client = new HttpClient(_server);
-            var result = client.GetAsync(_url + "Get_until25012015_1700").Result;
-            var clientTimeSpanSeconds = new SpecificTime(2017, 01, 25, 17, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds;
-            var resultCacheControlSeconds = ((TimeSpan) result.Headers.CacheControl.MaxAge).TotalSeconds;
+            var result = client.GetAsync(_url + "Get_until25012020_1700").Result;
+            var clientTimeSpanSeconds = new SpecificTime(2020, 01, 25, 17, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds;
+            var resultCacheControlSeconds = ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds;
             Assert.IsTrue(Math.Round(clientTimeSpanSeconds - resultCacheControlSeconds) == 0);
             Assert.IsFalse(result.Headers.CacheControl.MustRevalidate);
         }
@@ -135,7 +135,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "Get_until2355_today").Result;
 
-            Assert.IsTrue(Math.Round(new ThisDay(23,55,59).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
+            Assert.IsTrue(Math.Round(new ThisDay(23, 55, 59).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
             Assert.IsFalse(result.Headers.CacheControl.MustRevalidate);
         }
 
@@ -145,7 +145,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "Get_until27_thismonth").Result;
 
-            Assert.IsTrue(Math.Round(new ThisMonth(27,0,0,0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
+            Assert.IsTrue(Math.Round(new ThisMonth(27, 0, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
             Assert.IsFalse(result.Headers.CacheControl.MustRevalidate);
         }
 
@@ -183,7 +183,7 @@ namespace WebApi.OutputCache.V2.Tests
         {
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "Get_c100_s100_sm200").Result;
-            Assert.AreEqual(result.Headers.CacheControl.SharedMaxAge,TimeSpan.FromSeconds(200));
+            Assert.AreEqual(result.Headers.CacheControl.SharedMaxAge, TimeSpan.FromSeconds(200));
         }
 
         [Test]

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
 using WebApi.OutputCache.V2.TimeAttributes;
 
 namespace WebApi.OutputCache.V2.Tests.TestControllers
@@ -25,17 +27,17 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "test";
         }
 
-        [CacheOutput(NoCache=true)]
+        [CacheOutput(NoCache = true)]
         public string Get_nocache()
         {
             return "test";
         }
 
-		[CacheOutput(ClientTimeSpan = 0, ServerTimeSpan = 100, MustRevalidate = true)]
-		public string Get_c0_s100_mustR()
-		{
-			return "test";
-		}
+        [CacheOutput(ClientTimeSpan = 0, ServerTimeSpan = 100, MustRevalidate = true)]
+        public string Get_c0_s100_mustR()
+        {
+            return "test";
+        }
 
         [CacheOutput(ClientTimeSpan = 50, MustRevalidate = true)]
         public string Get_c50_mustR()
@@ -64,7 +66,7 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
         [CacheOutput(ServerTimeSpan = 50, ExcludeQueryStringFromCacheKey = false)]
         public string Get_s50_exclude_false(int id)
         {
-            return "test"+id;
+            return "test" + id;
         }
 
         [CacheOutput(ServerTimeSpan = 50, ExcludeQueryStringFromCacheKey = true)]
@@ -73,13 +75,13 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "test" + id;
         }
 
-        [CacheOutputUntil(2017,01,25,17,00)]
-        public string Get_until25012015_1700()
+        [CacheOutputUntil(2020, 01, 25, 17, 00)]
+        public string Get_until25012020_1700()
         {
             return "test";
         }
 
-        [CacheOutputUntilToday(23,55)]
+        [CacheOutputUntilToday(23, 55)]
         public string Get_until2355_today()
         {
             return "value";
@@ -91,7 +93,7 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "value";
         }
 
-        [CacheOutputUntilThisYear(7,31)]
+        [CacheOutputUntilThisYear(7, 31)]
         public string Get_until731_thisyear()
         {
             return "value";
@@ -125,7 +127,7 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
         [CacheOutput(ClientTimeSpan = 50, ServerTimeSpan = 50)]
         public string Get_request_httpResponseException_noCache()
         {
-            throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.Conflict){ReasonPhrase = "Fault shouldn't cache"});
+            throw new HttpResponseException(new HttpResponseMessage(HttpStatusCode.Conflict) { ReasonPhrase = "Fault shouldn't cache" });
         }
 
         [CacheOutput(ClientTimeSpan = 50, ServerTimeSpan = 50)]

--- a/test/WebApi.OutputCache.V2.Tests/packages.config
+++ b/test/WebApi.OutputCache.V2.Tests/packages.config
@@ -6,5 +6,13 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" userInstalled="true" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" userInstalled="true" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" userInstalled="true" />
-  <package id="NUnit" version="2.6.2" targetFramework="net45" userInstalled="true" />
+  <package id="NUnit" version="3.6.0" targetFramework="net45" userInstalled="true" />
+  <package id="NUnit.Console" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net45" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.6.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
1) Added Support for "cache-control:no-cache" in request
2) Updated CacheOutputUntil in client side unit test
3) Updated NUnit version and added test runner