### PR TITLE
Allow bypassing content negotiation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ So you either should use unique method names inside a single controller, or (if 
             return Teams;
         }
 
+If you want to bypass the content negotiation process, you can do so by using the `MediaType` property:
+
+        [CacheOutput(ClientTimeSpan = 50, ServerTimeSpan = 50, MediaType = "image/jpeg")]
+        public HttpResponseMessage Get(int id)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Content = GetImage(id); // e.g. StreamContent, ByteArrayContent,...
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+            return response;
+        }
+
+This will always return a response with `image/jpeg` as value for the `Content-Type` header.
 
 Ignoring caching
 --------------------

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -49,7 +49,7 @@ namespace WebApi.OutputCache.V2
         /// </summary>
         public int ClientTimeSpan { get; set; }
 
-
+        
         private int? _sharedTimeSpan = null;
 
         /// <summary>
@@ -80,7 +80,12 @@ namespace WebApi.OutputCache.V2
         /// Class used to generate caching keys
         /// </summary>
         public Type CacheKeyGenerator { get; set; }
-        
+
+        /// <summary>
+        /// If set to something else than an empty string, this value will always be used for the Content-Type header, regardless of content negotiation.
+        /// </summary>
+        public string MediaType { get; set; }
+
         // cache repository
         private IApiOutputCache _webApiCache;
 
@@ -121,6 +126,11 @@ namespace WebApi.OutputCache.V2
 
         protected virtual MediaTypeHeaderValue GetExpectedMediaType(HttpConfiguration config, HttpActionContext actionContext)
         {
+            if (!string.IsNullOrEmpty(MediaType))
+            {
+                return new MediaTypeHeaderValue(MediaType);
+            }
+
             MediaTypeHeaderValue responseMediaType = null;
 
             var negotiator = config.Services.GetService(typeof(IContentNegotiator)) as IContentNegotiator;

--- a/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
@@ -338,6 +338,19 @@ namespace WebApi.OutputCache.V2.Tests
         //    _cache.Verify(s => s.Add(It.Is<string>(x => x == "custom_key:response-ct"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "cachekey-get_custom_key")), Times.Once());
         //}
 
+        [Test]
+        public void override_mediatype()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Get_c50_s50_image");
+            var result = client.SendAsync(req).Result;
+
+            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c50_s50_image:image/jpeg")), Times.Exactly(2));
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c50_s50_image"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c50_s50_image:image/jpeg"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c50_s50_image")), Times.Once());
+            Assert.That(result.Content.Headers.ContentType, Is.EqualTo(new MediaTypeHeaderValue("image/jpeg")));
+        }
+
         [TearDown]
         public void fixture_dispose()
         {

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Web.Http;
 using WebApi.OutputCache.V2.TimeAttributes;
 
@@ -132,6 +133,14 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
         public HttpResponseMessage Get_request_noContent()
         {
             return Request.CreateResponse(HttpStatusCode.Accepted);
+        }
+
+        [CacheOutput(ClientTimeSpan = 50, ServerTimeSpan = 50, MediaType = "image/jpeg")]
+        public HttpResponseMessage Get_c50_s50_image()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK) {Content = new ByteArrayContent(new byte[0])};
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+            return response;
         }
 
         [InvalidateCacheOutput("Get_c100_s100")]


### PR DESCRIPTION
This PR allows to set a `MediaType` property like this:

```
[CacheOutput(ClientTimeSpan = 50, ServerTimeSpan = 50, MediaType = "image/jpeg")]
public HttpResponseMessage Get(int id)
{
    var response = new HttpResponseMessage(HttpStatusCode.OK);
    response.Content = GetImage(id); // e.g. StreamContent, ByteArrayContent,...
    response.Content.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
    return response;
}
```

This wil store the item as the given media type and always return it in this way.